### PR TITLE
docker-composeとcircleciへと構成を再構築

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+
+    working_directory: ~/app
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install docker-compose
+          command: |
+            set -x
+            curl -L https://github.com/docker/compose/releases/download/1.26.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+
+      - setup_remote_docker
+
+      - run:
+          name: Build Docker
+          command: docker-compose build
+
+      - run:
+          name: Docker-compose up
+          command:
+            docker-compose up -d
+
+      - run:
+          name: Finish message
+          command: echo "finish build."
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM elixir:1.10.4-alpine
+
+WORKDIR /app
+
+RUN mix local.hex --force
+RUN mix local.rebar --force

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CircleCI and Elixir
 
-<!-- [![miolab](https://circleci.com/gh/miolab/circleci_elixir.svg?style=svg)](https://github.com/miolab/circleci_elixir) -->
+[![miolab](https://circleci.com/gh/miolab/circleci_elixir.svg?style=svg)](https://github.com/miolab/circleci_elixir)
 
-__Elixir__ のDocker開発環境に __CircleCI__ を連携します
+__Elixir__ の __Docker__ 開発環境を構築し、__CircleCI__ と連携します
 
 ### 参考
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  web:
+    build: .
+
+    # phoenix使っておらずport設定してないので、コンテナ起動永続化させるため以下設定しておく
+    tty: true
+
+    working_dir: /app
+
+    volumes:
+      - .:/app


### PR DESCRIPTION
最初の連携確認のため、Elixirコンテナはまず最小構成としています