### PR TITLE
Qiita Advent Calendar用に、内容を一部カスタマイズする（mix format 導入）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             set -x
             docker-compose restart
-            docker-compose run --rm app sh -c "pwd && ls && cd my_app && mix format --check-format"
+            docker-compose run --rm app sh -c "pwd && ls && cd my_app && mix format --check-formatted"
 
       - run:
           name: Mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,13 @@ jobs:
             docker-compose logs
 
       - run:
+          name: Mix format
+          command: |
+            set -x
+            docker-compose restart
+            docker-compose run --rm app sh -c "pwd && ls && cd my_app && mix format --check-format"
+
+      - run:
           name: Mix test
           command: |
             set -x

--- a/README.md
+++ b/README.md
@@ -389,6 +389,43 @@ $ tree -L 2 -a
 
   All Green でパスしていることを確認できました
 
+### __mix format__
+
+コードをフォーマットします
+
+- フォーマットされているかチェック （`mix format  --check-formatted`）
+
+  ```terminal
+  $ docker-compose run --rm app sh -c "cd my_app && mix format --check-formatted"
+  Creating phoenix_dev_containers_app_run ... done
+  ** (Mix) mix format failed due to --check-formatted.
+  The following files are not formatted:
+
+    * test/my_app_web/controllers/user_controller_test.exs
+    * test/my_app/accounts_test.exs
+    * config/test.exs
+    * lib/my_app_web/router.ex
+    * priv/repo/migrations/20201122221317_create_users.exs
+  ```
+
+  フォーマットされていない場合は、上記のように警告表示されます
+
+- フォーマットをかける （`mix format`）
+
+  ```terminal
+  $ docker-compose run --rm app sh -c "cd my_app && mix format"
+  Creating phoenix_dev_containers_app_run ... done
+  ```
+
+- 結果確認
+
+  ```terminal
+  $ docker-compose run --rm app sh -c "cd my_app && mix format --check-formatted"
+  Creating phoenix_dev_containers_app_run ... done
+  ```
+
+  ぶじにフォーマットされました
+
 ---
 
 ## :book: 参考

--- a/app/my_app/config/test.exs
+++ b/app/my_app/config/test.exs
@@ -7,9 +7,9 @@ use Mix.Config
 # Run `mix help test` for more information.
 config :my_app, MyApp.Repo,
   username: "postgres",
-password: "password",    # --> update
+  password: "password",
   database: "my_app_test#{System.get_env("MIX_TEST_PARTITION")}",
-hostname: "db",    # --> update
+  hostname: "db",
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,

--- a/app/my_app/lib/my_app_web/router.ex
+++ b/app/my_app/lib/my_app_web/router.ex
@@ -17,7 +17,7 @@ defmodule MyAppWeb.Router do
     pipe_through(:browser)
 
     get("/", PageController, :index)
-    resources "/users", UserController    # -> add
+    resources "/users", UserController
     get("/aboutme", AboutmeController, :index)
   end
 

--- a/app/my_app/priv/repo/migrations/20201122221317_create_users.exs
+++ b/app/my_app/priv/repo/migrations/20201122221317_create_users.exs
@@ -9,6 +9,5 @@ defmodule MyApp.Repo.Migrations.CreateUsers do
 
       timestamps()
     end
-
   end
 end

--- a/app/my_app/test/my_app/accounts_test.exs
+++ b/app/my_app/test/my_app/accounts_test.exs
@@ -7,7 +7,11 @@ defmodule MyApp.AccountsTest do
     alias MyApp.Accounts.User
 
     @valid_attrs %{bio: "some bio", email: "some email", name: "some name"}
-    @update_attrs %{bio: "some updated bio", email: "some updated email", name: "some updated name"}
+    @update_attrs %{
+      bio: "some updated bio",
+      email: "some updated email",
+      name: "some updated name"
+    }
     @invalid_attrs %{bio: nil, email: nil, name: nil}
 
     def user_fixture(attrs \\ %{}) do

--- a/app/my_app/test/my_app_web/controllers/user_controller_test.exs
+++ b/app/my_app/test/my_app_web/controllers/user_controller_test.exs
@@ -75,6 +75,7 @@ defmodule MyAppWeb.UserControllerTest do
     test "deletes chosen user", %{conn: conn, user: user} do
       conn = delete(conn, Routes.user_path(conn, :delete, user))
       assert redirected_to(conn) == Routes.user_path(conn, :index)
+
       assert_error_sent 404, fn ->
         get(conn, Routes.user_path(conn, :show, user))
       end


### PR DESCRIPTION
予定

- .circleci/config.yml の不要フローを削除

- mix format 導入

```
$ docker-compose run --rm app sh -c "cd my_app && mix format --check-formatted"
Creating phoenix_dev_containers_app_run ... done
** (Mix) mix format failed due to --check-formatted.
The following files are not formatted:

  * test/my_app_web/controllers/user_controller_test.exs
  * test/my_app/accounts_test.exs
  * config/test.exs
  * lib/my_app_web/router.ex
  * priv/repo/migrations/20201122221317_create_users.exs

```

```
$ docker-compose run --rm app sh -c "cd my_app && mix format"
Creating phoenix_dev_containers_app_run ... done

```

```
$ docker-compose run --rm app sh -c "cd my_app && mix format --check-formatted"
Creating phoenix_dev_containers_app_run ... done

```